### PR TITLE
Added four MRN testcases in build.py

### DIFF
--- a/kernels/build.py
+++ b/kernels/build.py
@@ -89,7 +89,6 @@ if args.GEN:
     gen_kernel("-i 'movq (%rsp,%rdx,1), %rcx' 'addq $1, (%rsp,%rdx,1)' -n16" , 'ldst-mrn-cancel')
     gen_kernel("-i 'movq (%rsp,1), %rcx' 'addq $1, (%rsp,1)' -n16", 'ldst-mrn')
 
-
     kernels.append("memcpy")
     kernels.append("pagefault")
     kernels.append("tripcount-mean")

--- a/kernels/build.py
+++ b/kernels/build.py
@@ -84,6 +84,10 @@ if args.GEN:
     gen_kernel("-i 'mov %r13,%r12' 'add %r14,%r12' NOP -n 14", 'mov-op-nop')
     gen_kernel("-i 'mov 0x0(%rsp),%r12' NOP 'add %r13,%r12' -n 14", 'ld-nop-op')
     gen_kernel("-i 'mov %r13,%r12' NOP 'add %r14,%r12' -n 14", 'mov-nop-op')
+    gen_kernel("-i 'incq (%rsp,%rdx,1)' 'decq (%rsp,%rdx,1)' -n1", 'incdec-mrn-cancel')
+    gen_kernel("-i 'incq (%rsp,1)' 'decq (%rsp,1)' -n1", 'incdec-mrn')
+    gen_kernel("-i 'movq (%rsp,%rdx,1), %rcx' 'addq $1, (%rsp,%rdx,1)' -n1" , 'ldst-mrn-cancel')
+    gen_kernel("-i 'movq (%rsp,1), %rcx' 'addq $1, (%rsp,1)' -n1", 'ldst-mrn')
 
     kernels.append("memcpy")
     kernels.append("pagefault")

--- a/kernels/build.py
+++ b/kernels/build.py
@@ -84,10 +84,11 @@ if args.GEN:
     gen_kernel("-i 'mov %r13,%r12' 'add %r14,%r12' NOP -n 14", 'mov-op-nop')
     gen_kernel("-i 'mov 0x0(%rsp),%r12' NOP 'add %r13,%r12' -n 14", 'ld-nop-op')
     gen_kernel("-i 'mov %r13,%r12' NOP 'add %r14,%r12' -n 14", 'mov-nop-op')
-    gen_kernel("-i 'incq (%rsp,%rdx,1)' 'decq (%rsp,%rdx,1)' -n1", 'incdec-mrn-cancel')
-    gen_kernel("-i 'incq (%rsp,1)' 'decq (%rsp,1)' -n1", 'incdec-mrn')
-    gen_kernel("-i 'movq (%rsp,%rdx,1), %rcx' 'addq $1, (%rsp,%rdx,1)' -n1" , 'ldst-mrn-cancel')
-    gen_kernel("-i 'movq (%rsp,1), %rcx' 'addq $1, (%rsp,1)' -n1", 'ldst-mrn')
+    gen_kernel("-i 'incq (%rsp,%rdx,1)' 'decq (%rsp,%rdx,1)' -n16", 'incdec-mrn-cancel')
+    gen_kernel("-i 'incq (%rsp,1)' 'decq (%rsp,1)' -n16", 'incdec-mrn')
+    gen_kernel("-i 'movq (%rsp,%rdx,1), %rcx' 'addq $1, (%rsp,%rdx,1)' -n16" , 'ldst-mrn-cancel')
+    gen_kernel("-i 'movq (%rsp,1), %rcx' 'addq $1, (%rsp,1)' -n16", 'ldst-mrn')
+
 
     kernels.append("memcpy")
     kernels.append("pagefault")


### PR DESCRIPTION
Purpose is to provide a user with an ability to evaluate the performance impact of code that is MRN'ble and code that has the MRN feature cancelled due to the use of an index register in the SIB operand.  